### PR TITLE
Delete routineExercise component

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -8,6 +8,7 @@ import { AddRoutineComponent } from './add-routine/add-routine.component';
 import { AddRoutineFinalComponent } from './add-routine-final/add-routine-final.component';
 import { RoutineComponent } from './routine/routine.component';
 import { AuthGuard, NoAuthGuard } from './auth/auth.guard';
+import { EditRoutineComponent } from './edit-routine/edit-routine.component';
 
 const routes: Routes = [
   { path: '', component: WelcomeComponent, data: { showFooter: false }, title: 'Welcome | Iron Track', canActivate: [NoAuthGuard] },
@@ -16,7 +17,8 @@ const routes: Routes = [
   { path: 'routines', component: HomeComponent, title: 'Routines | Iron Track', canActivate: [AuthGuard] },
   { path: 'routines/add-routine', component: AddRoutineComponent, title: 'Add Exercises | Iron Track', canActivate: [AuthGuard] },
   { path: 'routines/add-routine/final', component: AddRoutineFinalComponent, title: 'Name Routine | Iron Track', canActivate: [AuthGuard] },
-  { path: 'routines/:routine_id', component: RoutineComponent, canActivate: [AuthGuard] }
+  { path: 'routines/:routine_id', component: RoutineComponent, canActivate: [AuthGuard] },
+  { path: 'routines/:routine_id/edit', component: EditRoutineComponent, canActivate: [AuthGuard] }
 ];
 
 @NgModule({

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -14,6 +14,8 @@ import { AddRoutineComponent } from './add-routine/add-routine.component';
 import { AddRoutineFinalComponent } from './add-routine-final/add-routine-final.component';
 import { HttpClientModule } from '@angular/common/http';
 import { RoutineComponent } from './routine/routine.component';
+import { EditRoutineComponent } from './edit-routine/edit-routine.component';
+import { A11yModule } from '@angular/cdk/a11y';
 
 @NgModule({
   declarations: [
@@ -26,13 +28,15 @@ import { RoutineComponent } from './routine/routine.component';
     HomeComponent,
     AddRoutineComponent,
     AddRoutineFinalComponent,
-    RoutineComponent
+    RoutineComponent,
+    EditRoutineComponent
   ],
   imports: [
     BrowserModule,
     AppRoutingModule,
     ReactiveFormsModule,
-    HttpClientModule
+    HttpClientModule,
+    A11yModule
   ],
   providers: [],
   bootstrap: [AppComponent]

--- a/src/app/edit-routine/edit-routine.component.html
+++ b/src/app/edit-routine/edit-routine.component.html
@@ -1,0 +1,29 @@
+<section class="edit-routine">
+  <div *ngIf="isOpen" class="modal" cdkTrapFocus #modalContent="cdkTrapFocus">
+    <div class="modal__content">
+      <p class="modal__content--text">Are you sure you want to delete <strong>{{ excerciseToDelete?.exercise?.name }}</strong> from your routine?</p>
+      <p class="modal__content--text">This action can not be undone</p>
+      <div class="modal__btn--group">
+        <button type="button" class="modal__btn modal__btn--cancel" (click)="close()" autofocus>Cancel</button>
+        <button type="button" class="modal__btn modal__btn--delete" (click)="delete()">Delete</button>
+      </div>
+    </div>
+  </div>
+  <div class="edit-routine__container">
+      <h2 class="edit-routine__heading">{{ routine.name }}</h2>
+      <div *ngFor="let exercise of routine.exercises; index as i;" class="exercise__container">
+        <div class="exercise__header">
+          <div class="exercise__header--content">
+            <h4 class="exercise__header--name"> {{ exercise.exercise.name }}</h4>
+          </div>
+          <div>
+            <i class="fa-solid fa-pencil exercise__header--icon"></i>
+            <i class="fa-regular fa-trash-can exercise__header--icon" (click)="open(exercise.id)"></i>
+          </div>
+        </div>
+      </div>
+      <a href="#" class="btn edit-routine__btn--add">Add Exercise</a>
+      <a href="#" class="btn edit-routine__btn--cancel">Cancel</a>
+      <a href="#" class="btn  edit-routine__btn--finish">Finish Editing</a>
+  </div>
+</section>

--- a/src/app/edit-routine/edit-routine.component.html
+++ b/src/app/edit-routine/edit-routine.component.html
@@ -23,7 +23,6 @@
         </div>
       </div>
       <a href="#" class="btn edit-routine__btn edit-routine__btn--add">Add Exercise</a>
-      <a href="#" class="btn edit-routine__btn edit-routine__btn--cancel">Cancel</a>
       <a href="#" class="btn edit-routine__btn edit-routine__btn--finish">Finish Editing</a>
   </div>
 </section>

--- a/src/app/edit-routine/edit-routine.component.html
+++ b/src/app/edit-routine/edit-routine.component.html
@@ -16,14 +16,14 @@
           <div class="exercise__header--content">
             <h4 class="exercise__header--name"> {{ exercise.exercise.name }}</h4>
           </div>
-          <div>
-            <i class="fa-solid fa-pencil exercise__header--icon"></i>
-            <i class="fa-regular fa-trash-can exercise__header--icon" (click)="open(exercise.id)"></i>
+          <div class="exercise__btn-group">
+            <a [routerLink]="['/routines', routine.id, 'edit', exercise.id]" tabindex="0"><i class="fa-solid fa-pencil exercise__header--icon"></i></a>
+            <a role="button" tabindex="0" (click)="open(exercise.id)"><i class="fa-regular fa-trash-can exercise__header--icon"></i></a>
           </div>
         </div>
       </div>
-      <a href="#" class="btn edit-routine__btn--add">Add Exercise</a>
-      <a href="#" class="btn edit-routine__btn--cancel">Cancel</a>
-      <a href="#" class="btn  edit-routine__btn--finish">Finish Editing</a>
+      <a href="#" class="btn edit-routine__btn edit-routine__btn--add">Add Exercise</a>
+      <a href="#" class="btn edit-routine__btn edit-routine__btn--cancel">Cancel</a>
+      <a href="#" class="btn edit-routine__btn edit-routine__btn--finish">Finish Editing</a>
   </div>
 </section>

--- a/src/app/edit-routine/edit-routine.component.scss
+++ b/src/app/edit-routine/edit-routine.component.scss
@@ -1,0 +1,175 @@
+@use "@angular/material" as mat;
+@import '../../scss/abstracts/variables';
+@import '../../scss//custom-theme.scss';
+
+
+.modal {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 75vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: rgba(10, 10, 10, 0.8);
+
+  &__content {
+    max-width: 80%;
+    border-radius: 8px;
+    background-color: mat.get-color-from-palette($iron-track-dark-primary, 'default');
+
+    padding: $lg;
+    text-align: left;
+    border: 1px solid mat.get-color-from-palette($iron-track-accent, 'default');
+    &--text:last-of-type {
+      margin-top: $md;
+    }
+  }
+
+  &__btn {
+    border-radius: 8px;
+    padding: $sm $md;
+    margin-top: $md;
+    cursor: pointer;
+    &--group {
+      width: 100%;
+      display: flex;
+      justify-content: flex-end;
+    }
+
+    &--cancel {
+      background-color: transparent;
+      color: mat.get-color-from-palette($iron-track-accent, 'default');
+      border: 1px solid mat.get-color-from-palette($iron-track-accent, 'default');
+      margin-right: $md;
+    }
+
+    &--delete {
+      background-color: mat.get-color-from-palette($iron-track-warn, 'default');
+      color: mat.get-color-from-palette($iron-track-warn, 'default-contrast');
+      border: 1px solid mat.get-color-from-palette($iron-track-warn, 'default');
+    }
+  }
+}
+.edit-routine {
+  height: 75vh;
+  overflow-y: auto;
+  padding-top: $xl;
+  padding-bottom: $xl;
+  text-transform: uppercase;
+  position: relative;
+
+  &__container {
+      display: flex;
+      flex-flow: column nowrap;
+      justify-content: center;
+  }
+
+  &__heading {
+    letter-spacing: 3px;
+    text-indent: 3px;
+    font-weight: 200;
+    margin-bottom: $xl;
+
+  }
+}
+
+.exercise {
+
+  &__container {
+    margin-bottom: $lg;
+    &:last-of-type {
+      margin-bottom: $xl;
+    }
+  }
+
+  &__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    border-bottom: 1px solid mat.get-color-from-palette($iron-track-accent, 'default');
+    padding: $sm 0;
+
+    &--content {
+      display: flex;
+      align-items: center;
+
+    }
+
+    &--name {
+      white-space: nowrap;
+      overflow-x: auto;
+      max-width: 60vw;
+
+      &-icon {
+        margin-right: $md;
+        font-size: 2rem;
+        cursor: pointer;
+      }
+    }
+
+    &--icon {
+      transition: transform 0.2s ease;
+      font-size: 2rem;
+      cursor: pointer;
+    }
+  }
+
+  &__content {
+    max-height: 0;
+    overflow: hidden;
+    transition: max-height 0.2s ease;
+
+  }
+  &__table {
+    width: 100%;
+    border: 1px solid mat.get-color-from-palette($iron-track-accent, 'default');
+    border-top: none;
+    border-collapse: collapse;
+    letter-spacing: 1px;
+    text-indent: 1px;
+    transform-origin: top;
+
+
+    &--head-data {
+      padding: $sm 0;
+    }
+
+    &--body {
+      background-color: mat.get-color-from-palette($iron-track-accent, 'default');
+      color: mat.get-color-from-palette($iron-track-dark-primary, 'default');
+      &-data {
+        padding: $sm 0;
+      }
+    }
+  }
+}
+
+.fa-pencil {
+  color: mat.get-color-from-palette($iron-track-accent, 'default');
+  margin-right: $smmd;
+}
+
+.fa-trash-can {
+  color: mat.get-color-from-palette($iron-track-warn, 'default');
+}
+
+.rotate {
+  transform: rotate(-180deg);
+}
+
+.expand {
+  max-height: 10rem;
+}
+.btn__ghost {
+    border: 1px solid mat.get-color-from-palette($iron-track-dark-primary, 'default-contrast');
+    color: mat.get-color-from-palette($iron-track-dark-primary, 'default-contrast');
+    margin-bottom: $md;
+    border-radius: 8px;
+}
+.btn__fill {
+    background-color: #008000;
+    border: 1px solid #008000;
+    border-radius: 8px;
+}

--- a/src/app/edit-routine/edit-routine.component.scss
+++ b/src/app/edit-routine/edit-routine.component.scss
@@ -82,17 +82,10 @@
 
     &--add {
       border: 1px solid mat.get-color-from-palette($iron-track-accent, 'default');
-      background-color: mat.get-color-from-palette($iron-track-accent, 'default');
-      color: mat.get-color-from-palette($iron-track-accent, 'default-contrast');
-    }
-
-    &--cancel {
-      border: 1px solid mat.get-color-from-palette($iron-track-accent, 'default');
       color: mat.get-color-from-palette($iron-track-accent, 'default');
     }
 
     &--finish {
-
       background-color: #008000;
       border: 1px solid #008000;
 

--- a/src/app/edit-routine/edit-routine.component.scss
+++ b/src/app/edit-routine/edit-routine.component.scss
@@ -71,6 +71,32 @@
     text-indent: 3px;
     font-weight: 200;
     margin-bottom: $xl;
+  }
+
+  &__btn {
+    border-radius: 8px;
+
+    &:not(:last-child) {
+      margin-bottom: $md;
+    }
+
+    &--add {
+      border: 1px solid mat.get-color-from-palette($iron-track-accent, 'default');
+      background-color: mat.get-color-from-palette($iron-track-accent, 'default');
+      color: mat.get-color-from-palette($iron-track-accent, 'default-contrast');
+    }
+
+    &--cancel {
+      border: 1px solid mat.get-color-from-palette($iron-track-accent, 'default');
+      color: mat.get-color-from-palette($iron-track-accent, 'default');
+    }
+
+    &--finish {
+
+      background-color: #008000;
+      border: 1px solid #008000;
+
+    }
 
   }
 }
@@ -144,11 +170,16 @@
       }
     }
   }
+
+  &__btn-group {
+    & > a:not(:last-child) {
+      margin-right: $md;
+    }
+  }
 }
 
 .fa-pencil {
   color: mat.get-color-from-palette($iron-track-accent, 'default');
-  margin-right: $smmd;
 }
 
 .fa-trash-can {
@@ -161,15 +192,4 @@
 
 .expand {
   max-height: 10rem;
-}
-.btn__ghost {
-    border: 1px solid mat.get-color-from-palette($iron-track-dark-primary, 'default-contrast');
-    color: mat.get-color-from-palette($iron-track-dark-primary, 'default-contrast');
-    margin-bottom: $md;
-    border-radius: 8px;
-}
-.btn__fill {
-    background-color: #008000;
-    border: 1px solid #008000;
-    border-radius: 8px;
 }

--- a/src/app/edit-routine/edit-routine.component.spec.ts
+++ b/src/app/edit-routine/edit-routine.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { EditRoutineComponent } from './edit-routine.component';
+
+describe('EditRoutineComponent', () => {
+  let component: EditRoutineComponent;
+  let fixture: ComponentFixture<EditRoutineComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [EditRoutineComponent]
+    });
+    fixture = TestBed.createComponent(EditRoutineComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/edit-routine/edit-routine.component.ts
+++ b/src/app/edit-routine/edit-routine.component.ts
@@ -1,0 +1,82 @@
+import { AfterViewInit, Component } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { RoutineService } from 'src/shared/services/routine.service';
+import { Routine } from 'src/shared/types/Routine';
+import { RoutineExercise } from 'src/shared/types/RoutineExercise';
+import { ElementRef, ViewChild } from '@angular/core';
+import { RoutineExerciseService } from 'src/shared/services/routine-exercise.service';
+
+@Component({
+  selector: 'app-edit-routine',
+  templateUrl: './edit-routine.component.html',
+  styleUrls: ['./edit-routine.component.scss']
+})
+
+export class EditRoutineComponent implements AfterViewInit {
+
+  @ViewChild('modalContent', { read: ElementRef, static: true }) modalContent!: ElementRef;
+
+  ngAfterViewInit(): void {
+    this.modalContent.nativeElement.focus();
+  }
+
+  routine: Routine;
+  expand: boolean[];
+  isOpen: boolean = false;
+  excerciseToDelete?: RoutineExercise;
+
+  handleExpand(i: number) {
+    this.expand[i] = !this.expand[i];
+  }
+
+  open(id: number | undefined) {
+    this.isOpen = true;
+    this.excerciseToDelete = this.routine.exercises.find(exercise => exercise.id === id);
+    this.modalContent.nativeElement.focus();
+  }
+
+  close() {
+    this.isOpen = false;
+    this.excerciseToDelete = undefined;
+  }
+
+  delete() {
+    console.log('Will delete ', this.excerciseToDelete);
+    this.routineExerciseService.delete(this.routine.id, this.excerciseToDelete?.id).subscribe({
+      next: () => {
+        window.location.reload();
+      },
+      error: (error) => {
+        console.log(error);
+      }
+    });
+  }
+
+  constructor(
+    private route: ActivatedRoute,
+    private router: Router,
+    private routineService: RoutineService,
+    private routineExerciseService: RoutineExerciseService
+  ) {
+    const routineId = this.route.snapshot.params['routine_id'];
+    this.routine = { name: '', exercises: [] };
+    this.routineService.retrieveRoutine(routineId).subscribe({
+      next: (data: {routine: Routine}) => {
+        this.routine = data.routine;
+      },
+      error: (error) => {
+        this.router.navigate(['/routines']);
+
+        if (error.error.statusCode === 404) {
+          console.error('Routine was not found', error);
+        } else if (error.error.statusCode === 403) {
+          console.error('User not authorized to view resource', error);
+        } else {
+          console.error('Unhandled error', error);
+        }
+
+      }
+    });
+    this.expand = this.routine.exercises.map(() => false);
+  }
+}

--- a/src/app/routine/routine.component.html
+++ b/src/app/routine/routine.component.html
@@ -36,7 +36,7 @@
             </table>
           </div>
         </div>
-        <a href="#" class="btn btn__ghost">Edit Routine</a>
+        <a [routerLink]="['/routines', routine.id, 'edit']" class="btn btn__ghost">Edit Routine</a>
         <a href="#" class="btn btn__fill">Begin Workout</a>
     </div>
 </section>

--- a/src/shared/services/routine-exercise.service.spec.ts
+++ b/src/shared/services/routine-exercise.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { RoutineExerciseService } from './routine-exercise.service';
+
+describe('RoutineExerciseService', () => {
+  let service: RoutineExerciseService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(RoutineExerciseService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/shared/services/routine-exercise.service.ts
+++ b/src/shared/services/routine-exercise.service.ts
@@ -1,0 +1,16 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { AuthService } from './auth.service';
+import { Observable } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class RoutineExerciseService {
+
+  constructor(private http: HttpClient, private authService: AuthService) { }
+
+  delete(routine_id: number | undefined, routine_exercise_id: number| undefined): Observable<any> {
+    return this.http.delete(`/api/routines/${routine_id}/${routine_exercise_id}`, { headers: this.authService.getHeader() });
+  }
+}


### PR DESCRIPTION
This component sets up the 'delete an exercise' functionality that the trash can empowers the user to do. It will only be functional once [PR# 9](https://github.com/AkDProjects/IronTrackBE/pull/9) gets merged in the backend, since that sets up the delete route.

Here is /routines/:routine_id/edit
<img width="319" alt="Screenshot 2023-10-25 at 6 06 12 PM" src="https://github.com/canasmh/iron-track/assets/55603689/0fa5a433-6c71-4f3a-a868-a37707de5545">

Here is what happens if I click on the trash can:
<img width="319" alt="Screenshot 2023-10-25 at 6 06 36 PM" src="https://github.com/canasmh/iron-track/assets/55603689/6b3db873-a717-42ac-997d-fb6ee3b173be">

If I click on cancel, the modal closes. However if I click delete, the http DELETE request is made and browser reloads to show the updated routine:
<img width="319" alt="Screenshot 2023-10-25 at 6 07 21 PM" src="https://github.com/canasmh/iron-track/assets/55603689/07c53b96-7d2e-48f7-84b4-c4d1d752890e">


